### PR TITLE
fix for windows path issue #46

### DIFF
--- a/ta-sdk-spi/src/main/java/com/ibm/ta/sdk/spi/plugin/TADataCollector.java
+++ b/ta-sdk-spi/src/main/java/com/ibm/ta/sdk/spi/plugin/TADataCollector.java
@@ -176,7 +176,7 @@ public class TADataCollector {
             for (ContentMask mask : contentMasks) {
               for (String contentMaskFile : mask.getFiles()) {
                 // Use the original path of the file, not the new path where the file is copied to
-                String origPath = path.toAbsolutePath().toString().replaceFirst(auOutputDir.getAbsolutePath(), "");
+                String origPath = path.toAbsolutePath().toString().replace(auOutputDir.getAbsolutePath(), "");
 
                 logger.debug("Comparing file:" + origPath + " to contentMaskFile:" + contentMaskFile);
 


### PR DESCRIPTION
Signed-off-by: Kieran Geoghegan <Kieran.Geoghegan@ie.ibm.com>

Sample plugin does not run on Windows
https://github.com/IBM/transformation-advisor-sdk/issues/46

Using the String `replace` method instead of `replaceFirst` as `replace` does not use regex and so will not have issue with the '\' in the windows paths. In this case replace is sufficient, because the replacement text cannot appear more than once in the target string.

Test Cases Run on both Mac + Windows
- Run existing unit test cases
- Run sample plugin as directed in README 
