### PR TITLE
fix windows zip issue #40

### DIFF
--- a/ta-sdk-spi/src/main/java/com/ibm/ta/sdk/spi/util/Util.java
+++ b/ta-sdk-spi/src/main/java/com/ibm/ta/sdk/spi/util/Util.java
@@ -21,6 +21,9 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 public class Util {
+
+  private static final String ZIP_FILE_SEPARATOR = "/"; // File.separator should not be used in zips
+
   public static void zipDir(Path zipOutFile, File zipInDir) throws IOException {
     ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipOutFile.toFile()));
     addZipEntry(zipInDir, null, zos);
@@ -31,9 +34,9 @@ public class Util {
   private static void addZipEntry(File file, String parentDir, ZipOutputStream zos) throws IOException {
     // Add current file/dir
     zos.putNextEntry(new ZipEntry(
-            (parentDir != null ? parentDir + File.separator : "")  // Do not start with leading /
+            (parentDir != null ? parentDir + ZIP_FILE_SEPARATOR : "")  // Do not start with leading /
                     + file.getName()
-                    + (file.isDirectory() ? File.separator : "")  // Add trailing / to directories
+                    + (file.isDirectory() ? ZIP_FILE_SEPARATOR : "")  // Add trailing / to directories
     ));
     if (file.isFile()) {
       IOUtils.copy(new FileInputStream(file), zos);
@@ -42,7 +45,7 @@ public class Util {
 
     // Add subdir files
     if (file.isDirectory()) {
-      parentDir = (parentDir != null ? parentDir + File.separator : "") + file.getName();
+      parentDir = (parentDir != null ? parentDir + ZIP_FILE_SEPARATOR : "") + file.getName();
       for (File dirFile : file.listFiles()) {
         addZipEntry(dirFile, parentDir, zos);
       }


### PR DESCRIPTION
Signed-off-by: Kieran Geoghegan <Kieran.Geoghegan@ie.ibm.com>

zip archive created on Windows OS can't be properly unzipped on *nix 
https://github.com/IBM/transformation-advisor-sdk/issues/40

The method for creating zips inserts a File.separator. On windows the File.separator will resolve to a backslash and a backslash should not be used as a file separator in a zip archive. "All slashes MUST be forward slashes '/' as opposed to backwards slashes" 

Test cases run on Windows and Mac
- Run SamplePluginProviderTest. Check valid archive is created, and it can be unzipped on Windows and Mac.
