### PR TITLE
issue#27 - add version option to print SDK and plug-in version.

### DIFF
--- a/ta-sdk-core/src/main/resources/log4j2.xml
+++ b/ta-sdk-core/src/main/resources/log4j2.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
+    <Properties>
+        <!--if no env:TA_LOG_LEVEL, use this-->
+        <Property name="TA_SDK_LOG_LEVEL">debug</Property>
+    </Properties>
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{yyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
@@ -15,10 +19,10 @@
         </RollingFile>
     </Appenders>
     <Loggers>
-        <Logger name="com.ibm.ta-sdk" level="debug" additivity="true">
-            <appender-ref ref="RollingFile" level="debug" />
+        <Logger name="com.ibm.ta-sdk" additivity="true">
+            <appender-ref ref="RollingFile" />
         </Logger>
-        <Root level="debug">
+        <Root level="${env:TA_SDK_LOG_LEVEL}">
             <AppenderRef ref="RollingFile" />
         </Root>
     </Loggers>

--- a/ta-sdk-spi/src/main/java/com/ibm/ta/sdk/spi/plugin/TADataCollector.java
+++ b/ta-sdk-spi/src/main/java/com/ibm/ta/sdk/spi/plugin/TADataCollector.java
@@ -70,6 +70,13 @@ public class TADataCollector {
       return;
     }
 
+    // version command - lists the version for SDK and the provider
+    if (cliArguments.get(0).contains("version")) {
+      System.out.println("\n  Transformation Advisor SDK version: "+Util.getSDKVersion());
+      System.out.println("    - Plugin provider "+provider.getClass()+" version: "+provider.getVersion()+"\n");
+      return;
+    }
+
     // Find command and display help for that command
     if (cliArguments.contains("--help") || cliArguments.contains("-h")) {
       CliInputCommand commandHelp = findMatchingCommandForUsageHelp(cliArguments, providerCommands);
@@ -583,6 +590,10 @@ public class TADataCollector {
     String middleware = cliCommands.get(0);
     if (middleware.startsWith("-")) {
       System.out.println("\n" + getBaseHelp() + "\n");
+      return;
+    }
+    if (middleware.contains("version")) {
+      System.out.println("\n  Transformation Advisor SDK version: "+Util.getSDKVersion()+"\n");
       return;
     }
     cliCommands.remove(0); // Pop out middleware from CLI args

--- a/ta-sdk-spi/src/main/java/com/ibm/ta/sdk/spi/plugin/TADataCollector.java
+++ b/ta-sdk-spi/src/main/java/com/ibm/ta/sdk/spi/plugin/TADataCollector.java
@@ -71,7 +71,7 @@ public class TADataCollector {
     }
 
     // version command - lists the version for SDK and the provider
-    if (cliArguments.get(0).contains("version")) {
+    if (cliArguments.get(0).contains("version")||cliArguments.get(0).equals("-v") ) {
       System.out.println("\n  Transformation Advisor SDK version: "+Util.getSDKVersion());
       System.out.println("    - Plugin provider "+provider.getClass()+" version: "+provider.getVersion()+"\n");
       return;
@@ -537,7 +537,7 @@ public class TADataCollector {
     }
     return null;
   }
-
+/*
   private static void processInput(String[] args) {
     Properties cliArgs = new Properties();
     List<String> cliCommands = new LinkedList<>();
@@ -572,7 +572,7 @@ public class TADataCollector {
       }
     }
   }
-
+*/
   public static void main(String[] args) {
     List<String> cliCommands = new LinkedList<>();
 


### PR DESCRIPTION

```
bash-3.2$ java -jar target/ta-sdk-sample-0.6.0.jar version

  Transformation Advisor SDK version: 0.6.0

bash-3.2$ java -jar target/ta-sdk-sample-0.6.0.jar sample --version

  Transformation Advisor SDK version: 0.6.0
    - Plugin provider class com.ibm.ta.sdk.sample.SamplePluginProvider version: 0.6.0

bash-3.2$ 
```
Signed-off-by: Jianfeng Kong <jianfeng@ca.ibm.com>