### PR TITLE
Support JSON path key names containing `\`

### DIFF
--- a/ta-sdk-core/src/main/java/com/ibm/ta/sdk/core/assessment/GenericRecommendation.java
+++ b/ta-sdk-core/src/main/java/com/ibm/ta/sdk/core/assessment/GenericRecommendation.java
@@ -13,6 +13,7 @@ import com.ibm.ta.sdk.spi.collect.AssessmentUnit;
 import com.ibm.ta.sdk.spi.assess.ComplexityContributionJson;
 import com.ibm.ta.sdk.spi.assess.IssueCategoryJson;
 import com.ibm.ta.sdk.spi.recommendation.*;
+import com.ibm.ta.sdk.spi.validation.TaJsonFileValidator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -35,7 +36,7 @@ public class GenericRecommendation implements Recommendation {
 
 
   public GenericRecommendation(String assessmentName, Path issuesFile, Path issuesCatFile, Path complexityFile,
-                               Path targetFile) throws IOException {
+                               Path targetFile) throws IOException, TAException {
     this.assessmentName = assessmentName;
 
     // Complexity
@@ -43,6 +44,7 @@ public class GenericRecommendation implements Recommendation {
     complexityRules.addAll(ComplexityContributionJson.getComplexityContributionList(ccList));
 
     // Targets
+    TaJsonFileValidator.validateTarget(targetFile.toString());
     GenericTarget target = GenericUtil.getJsonObj(new TypeToken<GenericTarget>(){}, targetFile);
     targets.add(target);
 

--- a/ta-sdk-core/src/main/java/com/ibm/ta/sdk/core/detector/json/JsonIssueRuleTypeProvider.java
+++ b/ta-sdk-core/src/main/java/com/ibm/ta/sdk/core/detector/json/JsonIssueRuleTypeProvider.java
@@ -33,7 +33,7 @@ import static com.jayway.jsonpath.JsonPath.using;
 
 public class JsonIssueRuleTypeProvider implements IssueRuleTypeProvider {
   private static final String JSON_RULE_PROVIDER_NAME = "json";
-  private static Logger logger = LogManager.getLogger(IssueRuleProcessor.class.getName());
+  private static Logger logger = LogManager.getLogger(JsonIssueRuleTypeProvider.class.getName());
 
   public static final String QUERYPATHS_KEYNAME = "jsonQueryPath";
   public static final String PATHVAR_NOT_RESOLVE = "@nr.";
@@ -146,6 +146,9 @@ public class JsonIssueRuleTypeProvider implements IssueRuleTypeProvider {
               pathKey = filterPathKey;
             }
 
+            if (filterPath.contains("\\")) {
+              filterPath = filterPath.replace("\\", "\\\\");
+            }
             Object pathObj =  doc.read(filterPath + "['" + pathKey + "']");
             if (pathObj instanceof JSONArray) {
               String[] strValues = new String[((JSONArray) pathObj).size()];

--- a/ta-sdk-core/src/test/java/com/ibm/ta/sdk/core/assessment/TargetTest.java
+++ b/ta-sdk-core/src/test/java/com/ibm/ta/sdk/core/assessment/TargetTest.java
@@ -1,0 +1,74 @@
+/*
+ * (C) Copyright IBM Corp. 2019,2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.ta.sdk.core.assessment;
+
+import com.ibm.ta.sdk.spi.plugin.TAException;
+import com.ibm.ta.sdk.spi.recommendation.Target;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import static com.ibm.ta.sdk.core.util.Constants.*;
+import static com.ibm.ta.sdk.core.util.Constants.FILE_TARGET_JSON;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TargetTest {
+    public static final String TEST_RESOURCES_DIR = "src" + File.separator + "test" + File.separator + "resources";
+
+    @Test
+    public void validTargetTest() {
+        try {
+            Path targetJsonFile = new File(TEST_RESOURCES_DIR, "target/target.json").toPath();
+
+            GenericRecommendation rec = getRecommendation(targetJsonFile);
+            List<Target> targets = rec.getTargets();
+            assertEquals(1, targets.size());
+
+            Target target = targets.get(0);
+            assertEquals("testProduct", target.getProductName());
+            assertEquals("10.0.0", target.getProductVersion());
+            assertEquals("testRuntime", target.getRuntime());
+            assertEquals(Target.LocationType.Private, target.getLocation());
+            assertEquals(Target.PlatformType.Docker, target.getPlatform());
+        } catch (IOException | TAException e) {
+            throw new AssertionFailedError("Error generating recommendations", e);
+        }
+    }
+
+    @Test
+    public void nullTargetTest() {
+        Path targetJsonFile = new File(TEST_RESOURCES_DIR, "target/target_null.json").toPath();
+
+        Exception e = assertThrows(TAException.class, () -> {
+            getRecommendation(targetJsonFile);
+        });
+        assertTrue(e.getMessage().contains("Anomalies found."));
+    }
+
+
+    @Test
+    public void missingAttrTargetTest() {
+        Path targetJsonFile = new File(TEST_RESOURCES_DIR, "target/target_missing_attr.json").toPath();
+
+        Exception e = assertThrows(TAException.class, () -> {
+            getRecommendation(targetJsonFile);
+        });
+        assertTrue(e.getMessage().contains("Anomalies found."));
+    }
+
+    private GenericRecommendation getRecommendation(Path targetJsonFile) throws IOException, TAException {
+        Path complexityJsonFile = new File(TEST_RESOURCES_DIR, "assess" + File.separator + FILE_COMPLEXITY_JSON).toPath();
+        Path issueCatJsonFile = new File(TEST_RESOURCES_DIR, "assess" + File.separator + FILE_ISSUECAT_JSON).toPath();
+        Path issueJsonFile = new File(TEST_RESOURCES_DIR, "issue" + File.separator + "issue_attr_filter.json").toPath();
+
+        return new GenericRecommendation("assessment1", issueJsonFile,
+                    issueCatJsonFile, complexityJsonFile, targetJsonFile);
+    }
+}

--- a/ta-sdk-core/src/test/java/com/ibm/ta/sdk/core/detector/JsonDetectorTest.java
+++ b/ta-sdk-core/src/test/java/com/ibm/ta/sdk/core/detector/JsonDetectorTest.java
@@ -1,0 +1,336 @@
+/*
+ * (C) Copyright IBM Corp. 2019,2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.ta.sdk.core.detector;
+
+import com.ibm.ta.sdk.core.assessment.GenericRecommendation;
+import com.ibm.ta.sdk.core.collect.GenericAssessmentUnit;
+import com.ibm.ta.sdk.spi.plugin.TAException;
+import com.ibm.ta.sdk.spi.recommendation.Issue;
+import com.ibm.ta.sdk.spi.recommendation.Occurrence;
+import com.ibm.ta.sdk.spi.recommendation.Severity;
+import com.ibm.ta.sdk.spi.recommendation.Target;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.ibm.ta.sdk.core.util.Constants.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JsonDetectorTest {
+    public static final String TEST_RESOURCES_DIR = "src" + File.separator + "test" + File.separator + "resources";
+
+    /*
+     * Simple filter by attribute and checks the values for all the issue attributes are correct.
+     */
+    @Test
+    public void validIssueAttributesTest() {
+        try {
+            Path assessmentUnitFile = new File(TEST_RESOURCES_DIR, "collect/AssessmentUnit.json").toPath();
+            GenericAssessmentUnit au = new GenericAssessmentUnit(assessmentUnitFile, null);
+
+            Path issueJsonFile = new File(TEST_RESOURCES_DIR, "issue/issue_attr_filter.json").toPath();
+            GenericRecommendation rec = getRecommendation(issueJsonFile);
+            List<Target> targets = rec.getTargets();
+            assertEquals(1, targets.size());
+
+            Target target = targets.get(0);
+            List<Issue> issues = rec.getIssues(target, au);
+            assertEquals(1, issues.size());
+
+            Issue issue = issues.get(0);
+            assertEquals("MQCL03", issue.getId());
+            assertEquals("Contains a Full Repository.  Assess impact to other cluster members.", issue.getTitle());
+            assertEquals(1.0f, issue.getCost());
+            assertEquals(0.5f, issue.getOverheadCost());
+            assertEquals(0.5f, issue.getOccurrenceCost());
+            assertEquals(Arrays.asList("Update other Cluster members using IPAddresses to use the new IPAddress after migrating"),
+                    issue.getSolutionText());
+            assertEquals(Severity.potential, issue.getSeverity());
+            assertEquals("cluster", issue.getCategory().getId());
+            assertEquals(1, issue.getOccurrencesCount());
+
+            // Check occurrences
+            Occurrence occurrence = issue.getOccurrence();
+            Map<String, String> expectedFieldKeys = new HashMap<>();
+            expectedFieldKeys.put("cluster", "Cluster");
+            assertEquals(expectedFieldKeys, occurrence.getFieldKeys());
+            Map<String, String> expectedOcInstance = new HashMap<>();
+            expectedOcInstance.put("cluster", "INVENTORY");
+            assertEquals(Arrays.asList(expectedOcInstance), occurrence.getOccurrencesInstances());
+        } catch (IOException | TAException e) {
+            throw new AssertionFailedError("Error generating recommendations", e);
+        }
+    }
+
+    /*
+     * Test no matching issue found
+     */
+    @Test
+    public void issueNotFoundTest() {
+        try {
+            Path assessmentUnitFile = new File(TEST_RESOURCES_DIR, "collect/AssessmentUnit.json").toPath();
+            GenericAssessmentUnit au = new GenericAssessmentUnit(assessmentUnitFile, null);
+
+            Path issueJsonFile = new File(TEST_RESOURCES_DIR, "issue/issue_not_found.json").toPath();
+            GenericRecommendation rec = getRecommendation(issueJsonFile);
+            List<Target> targets = rec.getTargets();
+            assertEquals(1, targets.size());
+
+            Target target = targets.get(0);
+            List<Issue> issues = rec.getIssues(target, au);
+            assertEquals(0, issues.size());
+       } catch (IOException | TAException e) {
+            throw new AssertionFailedError("Error generating recommendations", e);
+        }
+    }
+
+    /*
+     * Test retrieval of parent attribute using @parent
+     */
+    @Test
+    public void parentAttributesTest() {
+        try {
+            Path assessmentUnitFile = new File(TEST_RESOURCES_DIR, "collect/AssessmentUnit.json").toPath();
+            GenericAssessmentUnit au = new GenericAssessmentUnit(assessmentUnitFile, null);
+
+            Path issueJsonFile = new File(TEST_RESOURCES_DIR, "issue/issue_parent_attr.json").toPath();
+            GenericRecommendation rec = getRecommendation(issueJsonFile);
+            List<Target> targets = rec.getTargets();
+            assertEquals(1, targets.size());
+
+            Target target = targets.get(0);
+            List<Issue> issues = rec.getIssues(target, au);
+            assertEquals(1, issues.size());
+
+            Issue issue = issues.get(0);
+
+            // Check occurrences
+            Occurrence occurrence = issue.getOccurrence();
+            Map<String, String> expectedFieldKeys = new HashMap<>();
+            expectedFieldKeys.put("queueName", "Queue name");
+            assertEquals(expectedFieldKeys, occurrence.getFieldKeys());
+            Map<String, String> expectedOcInstance = new HashMap<>();
+            expectedOcInstance.put("queueName", "NewYork");
+            assertEquals(Arrays.asList(expectedOcInstance), occurrence.getOccurrencesInstances());
+        } catch (IOException | TAException e) {
+            throw new AssertionFailedError("Error generating recommendations", e);
+        }
+    }
+
+
+    /*
+     * Test retrieval of nr attribute using @parent.
+     * This returns a static value for the attribute (everything after '@nr.').
+     * Another approach is not to use 'path' and introduce 'value'
+     */
+    @Test
+    public void nrAttributesTest() {
+        try {
+            Path assessmentUnitFile = new File(TEST_RESOURCES_DIR, "collect/AssessmentUnit.json").toPath();
+            GenericAssessmentUnit au = new GenericAssessmentUnit(assessmentUnitFile, null);
+
+            Path issueJsonFile = new File(TEST_RESOURCES_DIR, "issue/issue_nr_attr.json").toPath();
+            GenericRecommendation rec = getRecommendation(issueJsonFile);
+            List<Target> targets = rec.getTargets();
+            assertEquals(1, targets.size());
+
+            Target target = targets.get(0);
+            List<Issue> issues = rec.getIssues(target, au);
+            assertEquals(1, issues.size());
+
+            Issue issue = issues.get(0);
+
+            // Check occurrences
+            Occurrence occurrence = issue.getOccurrence();
+            Map<String, String> expectedFieldKeys = new HashMap<>();
+            expectedFieldKeys.put("cluster", "Cluster");
+            assertEquals(expectedFieldKeys, occurrence.getFieldKeys());
+            Map<String, String> expectedOcInstance = new HashMap<>();
+            expectedOcInstance.put("cluster", "MY_CLUSTER");
+            assertEquals(Arrays.asList(expectedOcInstance), occurrence.getOccurrencesInstances());
+        } catch (IOException | TAException e) {
+            throw new AssertionFailedError("Error generating recommendations", e);
+        }
+    }
+
+
+    /*
+     * Test attribute @resolvedFilterPath, which returns the JSON Path of the matching JSON object found
+     */
+    @Test
+    public void resolvedFilterPathtAttributesTest() {
+        try {
+            Path assessmentUnitFile = new File(TEST_RESOURCES_DIR, "collect/AssessmentUnit.json").toPath();
+            GenericAssessmentUnit au = new GenericAssessmentUnit(assessmentUnitFile, null);
+
+            Path issueJsonFile = new File(TEST_RESOURCES_DIR, "issue/issue_resolvedFilterPath_attr.json").toPath();
+            GenericRecommendation rec = getRecommendation(issueJsonFile);
+            List<Target> targets = rec.getTargets();
+            assertEquals(1, targets.size());
+
+            Target target = targets.get(0);
+            List<Issue> issues = rec.getIssues(target, au);
+            assertEquals(1, issues.size());
+
+            Issue issue = issues.get(0);
+
+            // Check occurrences
+            Occurrence occurrence = issue.getOccurrence();
+            Map<String, String> expectedFieldKeys = new HashMap<>();
+            expectedFieldKeys.put("cluster", "Cluster");
+            assertEquals(expectedFieldKeys, occurrence.getFieldKeys());
+            Map<String, String> expectedOcInstance = new HashMap<>();
+            expectedOcInstance.put("cluster", "[clusters][0]");
+            assertEquals(Arrays.asList(expectedOcInstance), occurrence.getOccurrencesInstances());
+        } catch (IOException | TAException e) {
+            throw new AssertionFailedError("Error generating recommendations", e);
+        }
+    }
+
+    /*
+     * Test filtering by @filterPathKey
+     */
+    @Test
+    public void filterPathKeyTest() {
+        try {
+            Path assessmentUnitFile = new File(TEST_RESOURCES_DIR, "collect/AssessmentUnit.json").toPath();
+            GenericAssessmentUnit au = new GenericAssessmentUnit(assessmentUnitFile, null);
+
+            Path issueJsonFile = new File(TEST_RESOURCES_DIR, "issue/issue_filterPathKey.json").toPath();
+            GenericRecommendation rec = getRecommendation(issueJsonFile);
+            List<Target> targets = rec.getTargets();
+            assertEquals(1, targets.size());
+
+            Target target = targets.get(0);
+            List<Issue> issues = rec.getIssues(target, au);
+            assertEquals(1, issues.size());
+
+            Issue issue = issues.get(0);
+
+            // Check occurrences
+            Occurrence occurrence = issue.getOccurrence();
+            Map<String, String> expectedFieldKeys = new HashMap<>();
+            expectedFieldKeys.put("channel", "Channel");
+            expectedFieldKeys.put("channelType", "Channel Type");
+            expectedFieldKeys.put("channelTypeName", "Channel Type Name");
+            assertEquals(expectedFieldKeys, occurrence.getFieldKeys());
+            Map<String, String> expectedOcInstance1 = new HashMap<>();
+            expectedOcInstance1.put("channel", "INVENTORY.LONDON");
+            expectedOcInstance1.put("channelType", "sendch");
+            expectedOcInstance1.put("channelTypeName", "Inventory");
+            Map<String, String> expectedOcInstance2 = new HashMap<>();
+            expectedOcInstance2.put("channel", "SYSTEM.AUTO.SVRCONN");
+            expectedOcInstance2.put("channelType", "rcvch");
+            expectedOcInstance2.put("channelTypeName", "Svr Conn");
+            Map<String, String> expectedOcInstance3 = new HashMap<>();
+            expectedOcInstance3.put("channel", "SYSTEM.DEF.CLUSSDR");
+            expectedOcInstance3.put("channelType", "sendch");
+            expectedOcInstance3.put("channelTypeName", "Cluster DR");
+            Map<String, String> expectedOcInstance4 = new HashMap<>();
+            expectedOcInstance4.put("channel", "SYSTEM.DEF.SVRCONN");
+            expectedOcInstance4.put("channelType", "rcvch");
+            expectedOcInstance4.put("channelTypeName", "Svr Conn 2");
+            assertEquals(Arrays.asList(expectedOcInstance1, expectedOcInstance2, expectedOcInstance3, expectedOcInstance4),
+                    occurrence.getOccurrencesInstances());
+        } catch (IOException | TAException e) {
+            throw new AssertionFailedError("Error generating recommendations", e);
+        }
+    }
+
+
+    /*
+     * Test query multiple config files using queryInputFile attribute
+     */
+    @Test
+    public void queryMultipleInputFileTest() {
+        try {
+            Path assessmentUnitFile = new File(TEST_RESOURCES_DIR, "collect/AssessmentUnit.json").toPath();
+            Path configFile1 = new File(TEST_RESOURCES_DIR,
+                    "configFiles" + File.separator + "configFile.json").toPath();
+            Path configFile2 = new File(TEST_RESOURCES_DIR,
+                    "configFiles" + File.separator + "configFile2.json").toPath();
+            GenericAssessmentUnit au = new GenericAssessmentUnit(assessmentUnitFile, Arrays.asList(configFile1, configFile2));
+
+            Path issueJsonFile = new File(TEST_RESOURCES_DIR, "issue/issue_queryMultipleInputFile.json").toPath();
+            GenericRecommendation rec = getRecommendation(issueJsonFile);
+            List<Target> targets = rec.getTargets();
+            assertEquals(1, targets.size());
+
+            Target target = targets.get(0);
+            List<Issue> issues = rec.getIssues(target, au);
+            assertEquals(1, issues.size());
+
+            Issue issue = issues.get(0);
+
+            // Check occurrences
+            Occurrence occurrence = issue.getOccurrence();
+            Map<String, String> expectedFieldKeys = new HashMap<>();
+            expectedFieldKeys.put("cluster", "Cluster");
+            assertEquals(expectedFieldKeys, occurrence.getFieldKeys());
+            Map<String, String> expectedOcInstance = new HashMap<>();
+            expectedOcInstance.put("cluster", "CORK");
+            Map<String, String> expectedOcInstance2 = new HashMap<>();
+            expectedOcInstance2.put("cluster", "TORONTO");
+            assertEquals(Arrays.asList(expectedOcInstance, expectedOcInstance2), occurrence.getOccurrencesInstances());
+        } catch (IOException | TAException e) {
+            throw new AssertionFailedError("Error generating recommendations", e);
+        }
+    }
+
+    /*
+     * Test query a single config files using queryInputFile attribute
+     */
+    @Test
+    public void querySingleInputFileTest() {
+        try {
+            Path assessmentUnitFile = new File(TEST_RESOURCES_DIR, "collect/AssessmentUnit.json").toPath();
+            Path configFile1 = new File(TEST_RESOURCES_DIR,
+                    "configFiles" + File.separator + "configFile.json").toPath();
+            Path configFile2 = new File(TEST_RESOURCES_DIR,
+                    "configFiles" + File.separator + "configFile2.json").toPath();
+            GenericAssessmentUnit au = new GenericAssessmentUnit(assessmentUnitFile, Arrays.asList(configFile1, configFile2));
+
+            Path issueJsonFile = new File(TEST_RESOURCES_DIR, "issue/issue_querySingleInputFile.json").toPath();
+            GenericRecommendation rec = getRecommendation(issueJsonFile);
+            List<Target> targets = rec.getTargets();
+            assertEquals(1, targets.size());
+
+            Target target = targets.get(0);
+            List<Issue> issues = rec.getIssues(target, au);
+            assertEquals(1, issues.size());
+
+            Issue issue = issues.get(0);
+
+            // Check occurrences
+            Occurrence occurrence = issue.getOccurrence();
+            Map<String, String> expectedFieldKeys = new HashMap<>();
+            expectedFieldKeys.put("cluster", "Cluster");
+            assertEquals(expectedFieldKeys, occurrence.getFieldKeys());
+            Map<String, String> expectedOcInstance = new HashMap<>();
+            expectedOcInstance.put("cluster", "TORONTO");
+            assertEquals(Arrays.asList(expectedOcInstance), occurrence.getOccurrencesInstances());
+        } catch (IOException | TAException e) {
+            throw new AssertionFailedError("Error generating recommendations", e);
+        }
+    }
+
+    private GenericRecommendation getRecommendation(Path issueJsonFile) throws IOException, TAException {
+        Path complexityJsonFile = new File(TEST_RESOURCES_DIR, "assess" + File.separator + FILE_COMPLEXITY_JSON).toPath();
+        Path issueCatJsonFile = new File(TEST_RESOURCES_DIR, "assess" + File.separator + FILE_ISSUECAT_JSON).toPath();
+        Path targetJsonFile = new File(TEST_RESOURCES_DIR, "target" + File.separator + FILE_TARGET_JSON).toPath();
+
+        return new GenericRecommendation("assessment1", issueJsonFile,
+                issueCatJsonFile, complexityJsonFile, targetJsonFile);
+    }
+
+}

--- a/ta-sdk-core/src/test/resources/assess/complexity.json
+++ b/ta-sdk-core/src/test/resources/assess/complexity.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "dns",
+    "name": "DNS Reconfiguration",
+    "description": "Issues that require DNS reconfiguration",
+    "complexityContribution": "simple",
+    "issues": [
+      "MQCL01"
+    ]
+  },
+  {
+    "id": "cluster",
+    "name": "Cluster Reconfiguration",
+    "description": "Issues that require cluster reconfiguration",
+    "complexityContribution": "moderate",
+    "issuesCategory": [
+      "cluster"
+    ]
+  }
+]

--- a/ta-sdk-core/src/test/resources/assess/issue-category.json
+++ b/ta-sdk-core/src/test/resources/assess/issue-category.json
@@ -1,0 +1,11 @@
+{
+  "security": {
+    "title": "Authentication considerations"
+  },
+  "exits": {
+    "title": "Exit and custom binary considerations"
+  },
+  "cluster": {
+    "title": "Cluster considerations"
+  }
+}

--- a/ta-sdk-core/src/test/resources/collect/AssessmentUnit.json
+++ b/ta-sdk-core/src/test/resources/collect/AssessmentUnit.json
@@ -1,0 +1,167 @@
+{
+  "metadata_version": "1.0.0.0",
+  "name": "NewYork",
+  "version": "8.0.0.9",
+  "chadexit": "",
+  "clwlexit": "",
+  "connAuth": "SYSTEM.DEFAULT.AUTHINFO.IDPWOS",
+  "clusters": [
+    {
+      "name": "INVENTORY",
+      "fullRepository": true
+    }
+  ],
+  "channels": [
+    {
+      "name": "INVENTORY.LONDON",
+      "type": 9,
+      "sendch": "Inventory",
+      "conname": [
+        "LONDON.CHSTORE.COM"
+      ],
+      "clusterNames": [
+        "INVENTORY"
+      ],
+      "mcatype": 2,
+      "mcausers": [
+        ""
+      ]
+    },
+    {
+      "name": "INVENTORY.NEWYORK",
+      "type": 8,
+      "clusterNames": [
+        "INVENTORY"
+      ],
+      "mcatype": 2
+    },
+    {
+      "name": "SYSTEM.AUTO.RECEIVER",
+      "type": 3,
+      "mcatype": 0
+    },
+    {
+      "name": "SYSTEM.AUTO.SVRCONN",
+      "type": 7,
+      "rcvch": "Svr Conn",
+      "mcatype": 0
+    },
+    {
+      "name": "SYSTEM.DEF.CLUSRCVR",
+      "type": 8,
+      "mcatype": 2
+    },
+    {
+      "name": "SYSTEM.DEF.CLUSSDR",
+      "type": 9,
+      "sendch": "Cluster DR",
+      "mcatype": 2,
+      "mcausers": [
+        ""
+      ]
+    },
+    {
+      "name": "SYSTEM.DEF.RECEIVER",
+      "type": 3,
+      "mcatype": 0
+    },
+    {
+      "name": "SYSTEM.DEF.REQUESTER",
+      "type": 4,
+      "mcatype": 1,
+      "mcausers": [
+        ""
+      ]
+    },
+    {
+      "name": "SYSTEM.DEF.SENDER",
+      "type": 1,
+      "mcatype": 1,
+      "mcausers": [
+        ""
+      ]
+    },
+    {
+      "name": "SYSTEM.DEF.SERVER",
+      "type": 2,
+      "mcatype": 1,
+      "mcausers": [
+        ""
+      ]
+    },
+    {
+      "name": "SYSTEM.DEF.SVRCONN",
+      "type": 7,
+      "rcvch": "Svr Conn 2",
+      "mcatype": 0
+    },
+    {
+      "name": "SYSTEM.DEF.CLNTCONN",
+      "type": 6,
+      "mcatype": 0,
+      "mcausers": [
+        ""
+      ]
+    }
+  ],
+  "security": {
+    "authentication": "IDPWOS",
+    "authRecord": [
+      {
+        "type": "queue",
+        "object": "NewYork",
+        "osGroup": "root"
+      },
+      {
+        "type": "queue",
+        "object": "NewYork",
+        "osGroup": "mqm"
+      }
+    ]
+  },
+  "qmini": {
+    "capabilties": {
+      "ExitPath": [
+        {
+          "name": "ExitPath",
+          "properties": {
+            "ExitsDefaultPath64": "/var/mqm/exits64",
+            "ExitsDefaultPath": "/var/mqm/exits"
+          }
+        }
+      ],
+      "ServiceComponent": [
+        {
+          "name": "ServiceComponent",
+          "properties": {
+            "ComponentDataSize": "0",
+            "Name": "MQSeries.UNIX.auth.service",
+            "Module": "amqzfu",
+            "Service": "AuthorizationService"
+          }
+        }
+      ],
+      "Service": [
+        {
+          "name": "Service",
+          "properties": {
+            "Name": "AuthorizationService",
+            "EntryPoints": "14"
+          }
+        }
+      ]
+    }
+  },
+  "processes": [
+    {
+      "name": "SYSTEM.DEFAULT.PROCESS",
+      "description": ""
+    }
+  ],
+  "services": [
+    {
+      "name": "SYSTEM.DEFAULT.SERVICE",
+      "description": ""
+    }
+  ]
+}

--- a/ta-sdk-core/src/test/resources/collect/environment.json
+++ b/ta-sdk-core/src/test/resources/collect/environment.json
@@ -1,0 +1,13 @@
+{
+  "domain": "testDomain",
+  "operatingSystem": "RedHat Enterprise 7",
+  "hostName": "testhost.rtp.raleigh.ibm.com",
+  "middlewareName": "testMiddleware",
+  "middlewareVersion": "10.0.o",
+  "middlewareInstallPath": "/opt/testmiddleware",
+  "middlewareDataPath": "/opt/testdata",
+  "middlewareMetadata": {"feature": "drilling"},
+  "assessmentName": "Installation1",
+  "assessmentType": "Installation",
+  "assessmentMetadata": {"test": "value"}
+}

--- a/ta-sdk-core/src/test/resources/configFiles/configFile.json
+++ b/ta-sdk-core/src/test/resources/configFiles/configFile.json
@@ -1,0 +1,14 @@
+{
+  "metadata_version": "1.0.0.0",
+  "name": "Toronto",
+  "version": "8.0.0.9",
+  "chadexit": "",
+  "clwlexit": "",
+  "connAuth": "SYSTEM.DEFAULT.AUTHINFO.IDPWOS",
+  "clusters": [
+    {
+      "name": "TORONTO",
+      "fullRepository": true
+    }
+  ]
+}

--- a/ta-sdk-core/src/test/resources/configFiles/configFile2.json
+++ b/ta-sdk-core/src/test/resources/configFiles/configFile2.json
@@ -1,0 +1,14 @@
+{
+  "metadata_version": "1.0.0.0",
+  "name": "Cork",
+  "version": "8.0.0.9",
+  "chadexit": "",
+  "clwlexit": "",
+  "connAuth": "SYSTEM.DEFAULT.AUTHINFO.IDPWOS",
+  "clusters": [
+    {
+      "name": "CORK",
+      "fullRepository": true
+    }
+  ]
+}

--- a/ta-sdk-core/src/test/resources/issue/issue_attr_filter.json
+++ b/ta-sdk-core/src/test/resources/issue/issue_attr_filter.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "MQCL03",
+    "title": "Contains a Full Repository.  Assess impact to other cluster members.",
+    "category": "cluster",
+    "issueOverhead": 0.5,
+    "occurrencesCost": 0.5,
+    "solutionText": [
+      "Update other Cluster members using IPAddresses to use the new IPAddress after migrating"
+    ],
+    "severity": "potential",
+    "matchCriteria": {
+      "ruleType": "json",
+      "jsonQueryPath": {
+        "fullRepository": "$.clusters[?(@.fullRepository == true)]"
+      },
+      "occurrenceAttr": {
+        "cluster": {
+          "title": "Cluster",
+          "path": "name"
+        }
+      }
+    }
+  }
+]

--- a/ta-sdk-core/src/test/resources/issue/issue_filterPathKey.json
+++ b/ta-sdk-core/src/test/resources/issue/issue_filterPathKey.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "MQEXIT01",
+    "title": "Channel Exits defined. Review whether usage affects your MQ deployment architecture when migrating.",
+    "category": "exits",
+    "issueOverhead": 1.0,
+    "occurrencesCost": 1.0,
+    "solutionText": [
+      "Check if Exit has been replaced with Product Capability in MQ 9 and adopt that instead."
+    ],
+    "severity": "potential",
+    "matchCriteria": {
+      "ruleType": "json",
+      "jsonQueryPath": {
+        "sendch": "$.channels[?(@.type in [9])]",
+        "rcvch": "$.channels[?(@.type in [7])]"
+      },
+      "occurrenceAttr": {
+        "channel": {
+          "title": "Channel",
+          "path": "name"
+        },
+        "channelType": {
+          "title": "Channel Type",
+          "path": "@filterPathKey"
+        },
+        "channelTypeName": {
+          "title": "Channel Type Name",
+          "path": "@filterPathKeyValue",
+          "countUnique": true
+        }
+      }
+    }
+  }
+]

--- a/ta-sdk-core/src/test/resources/issue/issue_not_found.json
+++ b/ta-sdk-core/src/test/resources/issue/issue_not_found.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "MQCL03",
+    "title": "Contains a Full Repository.  Assess impact to other cluster members.",
+    "category": "cluster",
+    "issueOverhead": 0.5,
+    "occurrencesCost": 0.5,
+    "solutionText": [
+      "Update other Cluster members using IPAddresses to use the new IPAddress after migrating"
+    ],
+    "severity": "potential",
+    "matchCriteria": {
+      "ruleType": "json",
+      "jsonQueryPath": {
+        "fullRepository": "$.clusters[?(@.fullRepository == false)]"
+      },
+      "occurrenceAttr": {
+        "cluster": {
+          "title": "Cluster",
+          "path": "name"
+        }
+      }
+    }
+  }
+]

--- a/ta-sdk-core/src/test/resources/issue/issue_nr_attr.json
+++ b/ta-sdk-core/src/test/resources/issue/issue_nr_attr.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "MQCL03",
+    "title": "Contains a Full Repository.  Assess impact to other cluster members.",
+    "category": "cluster",
+    "issueOverhead": 0.5,
+    "occurrencesCost": 0.5,
+    "solutionText": [
+      "Update other Cluster members using IPAddresses to use the new IPAddress after migrating"
+    ],
+    "severity": "potential",
+    "matchCriteria": {
+      "ruleType": "json",
+      "jsonQueryPath": {
+        "fullRepository": "$.clusters[?(@.fullRepository == true)]"
+      },
+      "occurrenceAttr": {
+        "cluster": {
+          "title": "Cluster",
+          "path": "@nr.MY_CLUSTER"
+        }
+      }
+    }
+  }
+]

--- a/ta-sdk-core/src/test/resources/issue/issue_parent_attr.json
+++ b/ta-sdk-core/src/test/resources/issue/issue_parent_attr.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "MQCL03",
+    "title": "Contains a Full Repository.  Assess impact to other cluster members.",
+    "category": "cluster",
+    "issueOverhead": 0.5,
+    "occurrencesCost": 0.5,
+    "solutionText": [
+      "Update other Cluster members using IPAddresses to use the new IPAddress after migrating"
+    ],
+    "severity": "potential",
+    "matchCriteria": {
+      "ruleType": "json",
+      "jsonQueryPath": {
+        "fullRepository": "$.clusters[?(@.fullRepository == true)]"
+      },
+      "occurrenceAttr": {
+        "queueName": {
+          "title": "Queue name",
+          "path": "@parent.name"
+        }
+      }
+    }
+  }
+]

--- a/ta-sdk-core/src/test/resources/issue/issue_queryMultipleInputFile.json
+++ b/ta-sdk-core/src/test/resources/issue/issue_queryMultipleInputFile.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "MQEXIT06",
+    "title": "Service defined. Analysis of the Service needs to be completed to see if there are custom binaries used",
+    "category": "exits",
+    "issueOverhead": 1.0,
+    "occurrencesCost": 1.0,
+    "solutionText": [
+      "Check if binary has been replaced with Product Capability in MQ 9 and adopt that instead."
+    ],
+    "severity": "critical",
+    "matchCriteria": {
+      "ruleType": "json",
+      "queryInputFile": {
+        "SampleConfigFile": "(.*).json"
+      },
+      "jsonQueryPath": {
+        "fullRepository": "$.clusters[?(@.fullRepository == true)]"
+      },
+      "occurrenceAttr": {
+        "cluster": {
+          "title": "Cluster",
+          "path": "name"
+        }
+      }
+    }
+  }
+]

--- a/ta-sdk-core/src/test/resources/issue/issue_querySingleInputFile.json
+++ b/ta-sdk-core/src/test/resources/issue/issue_querySingleInputFile.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "MQEXIT06",
+    "title": "Service defined. Analysis of the Service needs to be completed to see if there are custom binaries used",
+    "category": "exits",
+    "issueOverhead": 1.0,
+    "occurrencesCost": 1.0,
+    "solutionText": [
+      "Check if binary has been replaced with Product Capability in MQ 9 and adopt that instead."
+    ],
+    "severity": "critical",
+    "matchCriteria": {
+      "ruleType": "json",
+      "queryInputFile": {
+        "SampleConfigFile": "configFile.json"
+      },
+      "jsonQueryPath": {
+        "fullRepository": "$.clusters[?(@.fullRepository == true)]"
+      },
+      "occurrenceAttr": {
+        "cluster": {
+          "title": "Cluster",
+          "path": "name"
+        }
+      }
+    }
+  }
+]

--- a/ta-sdk-core/src/test/resources/issue/issue_resolvedFilterPath_attr.json
+++ b/ta-sdk-core/src/test/resources/issue/issue_resolvedFilterPath_attr.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "MQCL03",
+    "title": "Contains a Full Repository.  Assess impact to other cluster members.",
+    "category": "cluster",
+    "issueOverhead": 0.5,
+    "occurrencesCost": 0.5,
+    "solutionText": [
+      "Update other Cluster members using IPAddresses to use the new IPAddress after migrating"
+    ],
+    "severity": "potential",
+    "matchCriteria": {
+      "ruleType": "json",
+      "jsonQueryPath": {
+        "fullRepository": "$.clusters[?(@.fullRepository == true)]"
+      },
+      "occurrenceAttr": {
+        "cluster": {
+          "title": "Cluster",
+          "path": "@resolvedFilterPath"
+        }
+      }
+    }
+  }
+]

--- a/ta-sdk-core/src/test/resources/target/target.json
+++ b/ta-sdk-core/src/test/resources/target/target.json
@@ -1,0 +1,5 @@
+{
+  "productName": "testProduct",
+  "productVersion": "10.0.0",
+  "runtime": "testRuntime"
+}

--- a/ta-sdk-core/src/test/resources/target/target_missing_attr.json
+++ b/ta-sdk-core/src/test/resources/target/target_missing_attr.json
@@ -1,0 +1,4 @@
+{
+  "productVersion": "10.0.0",
+  "runtime": "testRuntime"
+}


### PR DESCRIPTION
#28 - Results in empty occurrences when path has a key name that contains `\`

I have a new testcase for this, but it will go in with the other target work.

As discussed with John and Aaron (IIB), I will also create a 0.5.5 release with this fix.

