### PR TITLE
Add additional validation tests to catch errors during build time.

### DIFF
--- a/ta-sdk-core/src/main/java/com/ibm/ta/sdk/core/assessment/GenericRecommendation.java
+++ b/ta-sdk-core/src/main/java/com/ibm/ta/sdk/core/assessment/GenericRecommendation.java
@@ -19,13 +19,19 @@ import com.ibm.ta.sdk.spi.validation.TaJsonFileValidator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static com.ibm.ta.sdk.core.util.Constants.*;
+import static com.ibm.ta.sdk.core.util.Constants.FILE_TARGETS_JSON;
 
 public class GenericRecommendation implements Recommendation {
   private IssueRuleProcessor rcm;
@@ -36,7 +42,6 @@ public class GenericRecommendation implements Recommendation {
   private List<Target> targets = new ArrayList<Target>();
 
   private static Logger logger = LogManager.getLogger(GenericRecommendation.class.getName());
-
 
   public GenericRecommendation(String assessmentName, Path issuesFile, Path issuesCatFile, Path complexityFile,
                                Path targetsFile) throws IOException, TAException {
@@ -64,6 +69,19 @@ public class GenericRecommendation implements Recommendation {
     String issueRulesJson = GenericUtil.readFileToString(issuesFile);
     rcm = new IssueRuleProcessor(issueRulesJson, issueCategoryMap);
 
+  }
+
+  public static GenericRecommendation createGenericRecommemndation(String assessmentName, String middlewareName) throws TAException, IOException {
+    String middlewareDir = File.separator + middlewareName + File.separator;
+    try {
+        return new GenericRecommendation(assessmentName,
+                Paths.get(GenericRecommendation.class.getResource(middlewareDir + FILE_ISSUES_JSON).toURI()),
+                Paths.get(GenericRecommendation.class.getResource(middlewareDir + FILE_ISSUECATS_JSON).toURI()),
+                Paths.get(GenericRecommendation.class.getResource(middlewareDir + FILE_COMPLEXITIES_JSON).toURI()),
+                Paths.get(GenericRecommendation.class.getResource(middlewareDir + FILE_TARGETS_JSON).toURI()));
+      } catch (URISyntaxException e) {
+        throw new TAException(e);
+      }
   }
 
   @Override

--- a/ta-sdk-core/src/main/java/com/ibm/ta/sdk/core/assessment/IssueRuleProcessor.java
+++ b/ta-sdk-core/src/main/java/com/ibm/ta/sdk/core/assessment/IssueRuleProcessor.java
@@ -79,6 +79,11 @@ public class IssueRuleProcessor {
       }
     }
 
+    // If no issues or issue categories in target, add all issues to target
+    if (target.getIssues().isEmpty() && target.getIssueCategories().isEmpty()) {
+      issueRulesSet.addAll(issueRulesMap.keySet());
+    }
+
     // Create issue rule array with only issues listed in the target
     JsonArray issueRulesJson = new JsonArray();
     for (String targetIssue : issueRulesSet.toArray(new String[]{})) {

--- a/ta-sdk-core/src/main/java/com/ibm/ta/sdk/core/plugin/GenericPluginProvider.java
+++ b/ta-sdk-core/src/main/java/com/ibm/ta/sdk/core/plugin/GenericPluginProvider.java
@@ -66,12 +66,6 @@ public abstract class GenericPluginProvider implements PluginProvider {
   @Override
   public List<Recommendation> getRecommendation(CliInputCommand cliInputCommand) throws TAException {
     try {
-
-      String middlewareDir = "/" + getMiddleware() + "/";
-      Path complexityJsonFile = Paths.get(GenericPluginProvider.class.getResource(middlewareDir + FILE_COMPLEXITIES_JSON).toURI());
-      Path issueCatJsonFile = Paths.get(GenericPluginProvider.class.getResource(middlewareDir + FILE_ISSUECATS_JSON).toURI());
-      Path issueJsonFile = Paths.get(GenericPluginProvider.class.getResource(middlewareDir + FILE_ISSUES_JSON).toURI());
-      Path targetJsonFile = Paths.get(GenericPluginProvider.class.getResource(middlewareDir + FILE_TARGETS_JSON).toURI());
       File outDir = Util.getOutputDir();
       List<Recommendation> recs = new ArrayList<>();
 
@@ -79,14 +73,12 @@ public abstract class GenericPluginProvider implements PluginProvider {
       for (File file: fileList) {
         if (file.isDirectory()) {
           String dirName = file.getName();
-          GenericRecommendation rec = new GenericRecommendation(dirName, issueJsonFile, issueCatJsonFile, complexityJsonFile, targetJsonFile);
+          GenericRecommendation rec = GenericRecommendation.createGenericRecommemndation(dirName, getMiddleware());
           recs.add(rec);
         }
       }
 
       return recs;
-    } catch (URISyntaxException e) {
-      throw new TAException(e);
     } catch (IOException e) {
       throw new TAException(e);
     }

--- a/ta-sdk-core/src/main/java/com/ibm/ta/sdk/core/validation/PluginProviderValidationTest.java
+++ b/ta-sdk-core/src/main/java/com/ibm/ta/sdk/core/validation/PluginProviderValidationTest.java
@@ -1,5 +1,8 @@
 package com.ibm.ta.sdk.core.validation;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import com.ibm.ta.sdk.core.assessment.json.TargetsJson;
 import com.ibm.ta.sdk.core.util.Constants;
@@ -12,6 +15,7 @@ import org.opentest4j.AssertionFailedError;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -119,6 +123,120 @@ public class PluginProviderValidationTest {
             throw new AssertionFailedError("Failed to get targets from targets.json", e);
         } catch (URISyntaxException e) {
             throw new AssertionFailedError("Failed to get targets for the FreeMarker templates", e);
+        }
+    }
+
+    /**
+     * Iterates through each issues.json and checks the the category matches with a category defined
+     * in the issue-categories.json.
+     */
+    @Test
+    public void validateIssueCategoryTest() {
+        String middlewareName = getMiddlewareName();
+        assertNotNull(middlewareName, "No system property for middleware('" + MIDDLEWARE_NAME_PROP + "' defined.");
+
+        // Read categories
+        JsonObject catsO = null;
+        try {
+            File categoriesJsonFile = new File(PLUGIN_RESOURCES_DIR + File.separator + middlewareName, Constants.FILE_ISSUECATS_JSON);
+            catsO = GenericUtil.getJson(categoriesJsonFile.toPath()).getAsJsonObject();
+        } catch (IOException e) {
+            throw new AssertionFailedError("Failed to parse " + Constants.FILE_ISSUECATS_JSON, e);
+        }
+
+        // Read issues.json and check each category
+        JsonElement issuesE = null;
+        try {
+            File issuesJsonFile = new File(PLUGIN_RESOURCES_DIR + File.separator + middlewareName, Constants.FILE_ISSUES_JSON);
+            issuesE = GenericUtil.getJson(issuesJsonFile.toPath());
+        } catch (IOException e) {
+            throw new AssertionFailedError("Failed to parse " + Constants.FILE_ISSUES_JSON, e);
+        }
+
+        JsonArray issuesA = issuesE.getAsJsonObject().get("issues").getAsJsonArray();
+        for (JsonElement issueE : issuesA) {
+            String category = issueE.getAsJsonObject().get("category").getAsString();
+            JsonElement categoriesCatE = catsO.get(category);
+            assertTrue(categoriesCatE != null, "No category with name '" + category + "' found in " + Constants.FILE_ISSUECATS_JSON);
+            assertTrue(categoriesCatE.isJsonObject() && categoriesCatE.getAsJsonObject().get("title") != null, "Category '" + category + "' is not a valid JsonObject in " + Constants.FILE_ISSUECATS_JSON);
+        }
+    }
+
+    /**
+     * Iterates through each issues.json and checks that each ID is unique
+     */
+    @Test
+    public void uniqueIssueIdTest() {
+        String middlewareName = getMiddlewareName();
+        assertNotNull(middlewareName, "No system property for middleware('" + MIDDLEWARE_NAME_PROP + "' defined.");
+
+        // Read issues.json and check that the ID is unique
+        JsonElement issuesE = null;
+        try {
+            File issuesJsonFile = new File(PLUGIN_RESOURCES_DIR + File.separator + middlewareName, Constants.FILE_ISSUES_JSON);
+            issuesE = GenericUtil.getJson(issuesJsonFile.toPath());
+        } catch (IOException e) {
+            throw new AssertionFailedError("Failed to parse " + Constants.FILE_ISSUES_JSON, e);
+        }
+
+        List<String> issueIdList = new ArrayList<>();
+        JsonArray issuesA = issuesE.getAsJsonObject().get("issues").getAsJsonArray();
+        for (JsonElement issueE : issuesA) {
+            String id = issueE.getAsJsonObject().get("id").getAsString();
+            if (issueIdList.contains(id)) {
+                assertTrue(false, "Duplicate issue with ID '" + id + "' found in " + Constants.FILE_ISSUES_JSON);
+            }
+            issueIdList.add(id);
+        }
+    }
+
+    /**
+     * Iterates through each issues.json and checks that a complexities.json entry exists for either the
+     * issue ID or category
+     */
+    @Test
+    public void issueComplexityExistTest() {
+        String middlewareName = getMiddlewareName();
+        assertNotNull(middlewareName, "No system property for middleware('" + MIDDLEWARE_NAME_PROP + "' defined.");
+
+        // Read complexities
+        JsonArray complexitiesA = null;
+        try {
+            File complexitiesJsonFile = new File(PLUGIN_RESOURCES_DIR + File.separator + middlewareName, Constants.FILE_COMPLEXITIES_JSON);
+            complexitiesA = GenericUtil.getJson(complexitiesJsonFile.toPath()).getAsJsonObject().get("complexities").getAsJsonArray();
+        } catch (IOException e) {
+            throw new AssertionFailedError("Failed to parse " + Constants.FILE_ISSUECATS_JSON, e);
+        }
+
+        List<String> complexityIssuesList = new ArrayList<>();
+        List<String> complexityCatsList = new ArrayList<>();
+        for (JsonElement complexity : complexitiesA) {
+            JsonElement complexityIssues = complexity.getAsJsonObject().get("issues");
+            if (complexityIssues != null) {
+                complexityIssues.getAsJsonArray().forEach(i -> complexityIssuesList.add(i.getAsString()));
+            }
+            JsonElement complexityCats = complexity.getAsJsonObject().get("issuesCategory");
+            if (complexityCats != null) {
+                complexityCats.getAsJsonArray().forEach(c -> complexityCatsList.add(c.getAsString()));
+            }
+        }
+
+        // Read issues.json and check that the ID is unique
+        JsonElement issuesE = null;
+        try {
+            File issuesJsonFile = new File(PLUGIN_RESOURCES_DIR + File.separator + middlewareName, Constants.FILE_ISSUES_JSON);
+            issuesE = GenericUtil.getJson(issuesJsonFile.toPath());
+        } catch (IOException e) {
+            throw new AssertionFailedError("Failed to parse " + Constants.FILE_ISSUES_JSON, e);
+        }
+
+        JsonArray issuesA = issuesE.getAsJsonObject().get("issues").getAsJsonArray();
+        for (JsonElement issueE : issuesA) {
+            String id = issueE.getAsJsonObject().get("id").getAsString();
+            String category = issueE.getAsJsonObject().get("category").getAsString();
+            assertTrue(complexityIssuesList.contains(id) || complexityCatsList.contains(category),
+                    "No matching complexity in " + Constants.FILE_COMPLEXITIES_JSON + " found for issue ID '" +
+                    id + "' or issue category '" + category + "'" );
         }
     }
 

--- a/ta-sdk-core/src/test/java/com/ibm/ta/sdk/core/assessment/TargetTest.java
+++ b/ta-sdk-core/src/test/java/com/ibm/ta/sdk/core/assessment/TargetTest.java
@@ -69,7 +69,7 @@ public class TargetTest {
             // No issue and no issue category
             Path targetJsonFile = new File(TEST_RESOURCES_DIR, "target/targets_no_issue_no_cat.json").toPath();
             List<Issue> issues = getIssue(targetJsonFile);
-            assertEquals(0, issues.size());
+            assertEquals(1, issues.size());
         } catch (IOException | TAException e) {
             throw new AssertionFailedError("Error generating recommendations", e);
         }

--- a/ta-sdk-sample/src/main/resources/middleware/complexities.json
+++ b/ta-sdk-sample/src/main/resources/middleware/complexities.json
@@ -34,6 +34,9 @@
       "complexityContribution": "complex",
       "issues": [
         "MQSEC01"
+      ],
+      "issuesCategory": [
+        "security"
       ]
     }
   ]


### PR DESCRIPTION
Add 3 validation tests to catch errors during building of the plug-in vs runtime errors:

1. Issue IDs are unique, no duplicates
2. Each issue in issues.json contains a category that is defined in issue-categories.json
3. Each issue in issues.json has a matching entry in complexities.json, either by issue ID or by issue category. This test did find an error in the sample plug-in, "usingDatasource" issue rule doesn't have a matching complexity defined in complexities.json.