### PR TITLE
Allow plugins to indicate it has sensitive data

### DIFF
--- a/ta-sdk-sample/src/main/java/com/ibm/ta/sdk/sample/SamplePluginProvider.java
+++ b/ta-sdk-sample/src/main/java/com/ibm/ta/sdk/sample/SamplePluginProvider.java
@@ -106,6 +106,7 @@ public class SamplePluginProvider extends GenericPluginProvider {
       envJson.setMiddlewareDataPath("/opt/instance/configPath");
       envJson.setCollectionUnitName(collectionUnitName);
       envJson.setCollectionUnitType("instance");
+      envJson.setHasSensitiveData(false);
 
 
       List<GenericAssessmentUnit> auList = new ArrayList<>();

--- a/ta-sdk-spi/src/main/java/com/ibm/ta/sdk/spi/collect/Environment.java
+++ b/ta-sdk-spi/src/main/java/com/ibm/ta/sdk/spi/collect/Environment.java
@@ -101,4 +101,12 @@ public interface Environment {
    * @return Additional metadata information about the assessment
    */
   JsonObject getAssessmentMetadata();
+
+  /**
+   * Indicate if the data collection contains sensitive data. If there is sensitive data, no zip archive is created
+   * during the assess command execution.
+   *
+   * @return True if the data collection contains sensitive data
+   */
+  boolean hasSensitiveData();
 }

--- a/ta-sdk-spi/src/main/java/com/ibm/ta/sdk/spi/collect/EnvironmentJson.java
+++ b/ta-sdk-spi/src/main/java/com/ibm/ta/sdk/spi/collect/EnvironmentJson.java
@@ -59,6 +59,9 @@ public class EnvironmentJson {
   @Expose
   private List<String> assessmentUnits;
 
+  @Expose
+  private boolean hasSensitiveData = true;
+
   public EnvironmentJson() {
     // For read json from file
   }
@@ -91,6 +94,7 @@ public class EnvironmentJson {
     if (environment.getAssessmentMetadata() != null) {
       assessmentMetadata = environment.getAssessmentMetadata();
     }
+    hasSensitiveData = environment.hasSensitiveData();
   }
 
   public Environment getEnvironment() {
@@ -155,6 +159,11 @@ public class EnvironmentJson {
         }
         return null;
       }
+
+      @Override
+      public boolean hasSensitiveData() {
+        return hasSensitiveData;
+      }
     };
     return environment;
   }
@@ -213,5 +222,9 @@ public class EnvironmentJson {
 
   public void setAssessmentUnits(List<String> auNamesList) {
     this.assessmentUnits = auNamesList;
+  }
+
+  public void setHasSensitiveData(boolean hasSensitiveData) {
+    this.hasSensitiveData = hasSensitiveData;
   }
 }

--- a/ta-sdk-spi/src/main/java/com/ibm/ta/sdk/spi/plugin/TADataCollector.java
+++ b/ta-sdk-spi/src/main/java/com/ibm/ta/sdk/spi/plugin/TADataCollector.java
@@ -318,7 +318,7 @@ public class TADataCollector {
 
       // Add log message to indicate zip does not contain data because plugin collects sensitive data
       if (environment.hasSensitiveData()) {
-        logger.info("The enivrnoment.json file indicates that the collection contains sensitive data. The collection zip archive created will not include any of the collected data files.");
+        logger.info("The environment.json file indicates that the collection contains sensitive data. The collection zip archive created will not include any of the collected data files.");
       }
 
       // zip output dir

--- a/ta-sdk-spi/src/main/java/com/ibm/ta/sdk/spi/plugin/TADataCollector.java
+++ b/ta-sdk-spi/src/main/java/com/ibm/ta/sdk/spi/plugin/TADataCollector.java
@@ -316,6 +316,11 @@ public class TADataCollector {
       File outputDir = Util.getAssessmentOutputDir(assessmentName);
       writeRecommendationsJson(recJson, outputDir);
 
+      // Add log message to indicate zip does not contain data because plugin collects sensitive data
+      if (environment.hasSensitiveData()) {
+        logger.info("The enivrnoment.json file indicates that the collection contains sensitive data. The collection zip archive created will not include any of the collected data files.");
+      }
+
       // zip output dir
       String zipFileName = environment.getCollectionUnitName() + ".zip";
       File zipFile = new File(outputDir.getParentFile(), zipFileName);

--- a/ta-sdk-spi/src/main/java/com/ibm/ta/sdk/spi/util/Util.java
+++ b/ta-sdk-spi/src/main/java/com/ibm/ta/sdk/spi/util/Util.java
@@ -8,12 +8,15 @@ package com.ibm.ta.sdk.spi.util;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.ibm.ta.sdk.spi.plugin.TADataCollector;
 import org.apache.commons.compress.utils.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.*;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -34,14 +37,38 @@ public class Util {
     }
     return version;
   }
-  public static void zipDir(Path zipOutFile, File zipInDir) throws IOException {
+
+  public static void zipCollection(Path zipOutFile, File zipInDir, boolean excludeData) throws IOException  {
     ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipOutFile.toFile()));
-    addZipEntry(zipInDir, null, zos);
+    zos.putNextEntry(new ZipEntry(zipInDir.getName() + ZIP_FILE_SEPARATOR));
+    zos.closeEntry();
+
+    // Add subdir files
+    String parentDir = zipInDir.getName();
+    for (File dirFile : zipInDir.listFiles()) {
+      if (excludeData) {
+        // If plugin has sensitive data, include only the metadata.assessmentunit.json and reports HTML files in
+        // each assessment unit dir
+        addZipEntry(dirFile, parentDir, zos, Arrays.asList(new String[]{
+                TADataCollector.ASSESSMENTUNIT_META_JSON_FILE,
+                "recommendations_.*.html"}));
+      } else {
+        addZipEntry(dirFile, parentDir, zos, null);
+      }
+    }
+
     zos.finish();
     zos.close();
   }
 
-  private static void addZipEntry(File file, String parentDir, ZipOutputStream zos) throws IOException {
+  public static void zipDir(Path zipOutFile, File zipInDir) throws IOException {
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipOutFile.toFile()));
+    addZipEntry(zipInDir, null, zos, null);
+    zos.finish();
+    zos.close();
+  }
+
+  private static void addZipEntry(File file, String parentDir, ZipOutputStream zos, List<String> includeFileList) throws IOException {
     // Add current file/dir
     zos.putNextEntry(new ZipEntry(
             (parentDir != null ? parentDir + ZIP_FILE_SEPARATOR : "")  // Do not start with leading /
@@ -57,9 +84,20 @@ public class Util {
     if (file.isDirectory()) {
       parentDir = (parentDir != null ? parentDir + ZIP_FILE_SEPARATOR : "") + file.getName();
       for (File dirFile : file.listFiles()) {
-        addZipEntry(dirFile, parentDir, zos);
+        if (includeFileList == null || hasMatchingFileName(includeFileList, dirFile.getName())) {
+          addZipEntry(dirFile, parentDir, zos, includeFileList);
+        }
       }
     }
+  }
+
+  private static boolean hasMatchingFileName(List<String> files, String fileName) {
+    for (String file : files) {
+      if (fileName.matches(file)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public static File getOutputDir() {


### PR DESCRIPTION
#77

Take 2, this version creates the collection zip and only includes metadata.assessmentunit.json and recommendations reports in each assessment unit (all other files/data are not included in the zip)

No new unit tests to test this functionality yet.