### PR TITLE
Upgrade Log4J 2.16.0 to 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <ta.sdk.version>0.6.1</ta.sdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <log4j.version>2.15.0</log4j.version>
+        <log4j.version>2.17.0</log4j.version>
         <junit5.version>5.6.0</junit5.version>
         <gson.version>2.8.5</gson.version>
     </properties>


### PR DESCRIPTION
Motivation:

Log4J upgrade to address a security risk CVE-2021-45105

Modifications:

Upgrade from 2.16.0 to 2.17.0

Result:

Using a safer Log4J version